### PR TITLE
CD - deploy to EC2 instance

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,7 +9,7 @@ name: Deploy
 
 on:
   workflow_run: # Only run this if linting and testing pass
-    workflows: ["Check"] # is this the correct workflow name? also dd lintint back later
+    workflows: [Lint, Check] # is this the correct workflow name? also dd lintint back later
     types: [completed] # don't know if this will work
     branches: alexi-deploy-cd
 
@@ -23,5 +23,5 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      - run: echo "First workflow was a failure"
+      - run: echo "Checks did not pass, no deployment"
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,23 +9,21 @@ name: Deploy
 
 on:
   workflow_run: # Only run this if linting and testing pass
-    workflows: [Lint, Check] # is this the correct workflow name? also dd lintint back later
-    types: [completed] # don't know if this will work
-    branches: alexi-deploy-cd
+    workflows: [Lint, Check] # Necessary checks
+    types: [completed] # Only run when the checks have completed
 
 jobs:
   on-success:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - run: echo "Checks pass, deploying"
-      - name: Deploy to EC2 instancd
-        if: github.ref == 'refs/heads/alexi-deploy-cd' # todo: rename to 'main'
+      - name: Deploy to EC2 instance
+        if: github.ref == 'refs/heads/main' # Only run on main branch
         uses: burnett01/rsync-deployments@5.1
         with:
           switches: -avzr --delete
-          path: ./homeassistant-config
-          remote_path: /home/homeassistant/
+          path: ./homeassistant-config/* # Home Assistant configuration path in the repo
+          remote_path: /home/homeassistant/ # Home Assistant configuration on the EC2 instance
           remote_host: ec2-35-91-223-141.us-west-2.compute.amazonaws.com # todo: make a repo variable?
           remote_user: ubuntu
           remote_key: "${{ secrets.SSH_PRIVATE_KEY }}"

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -11,7 +11,7 @@ on:
   workflow_run: # Only run this if linting and testing pass
     workflows: ["Check"] # is this the correct workflow name? also dd lintint back later
     types: [completed] # don't know if this will work
-    # branches: cd-alexi
+    branches: alexi-deploy-cd
 
 jobs:
   on-success:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,16 +19,16 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - run: echo "Checks pass, deploying"
-    - name: Deploy to EC2 instancd
-      if: github.ref == 'refs/heads/alexi-deploy-cd'
-      uses: burnett01/rsync-deployments@5.1
-      with:
-        switches: -avzr --delete
-        path: ./homeassistant-config
-        remote_path: /home/homeassistant/
-        remote_host: ec2-35-91-223-141.us-west-2.compute.amazonaws.com # todo: make a repo variable?
-        remote_user: ubuntu
-        remote_key: "${{ secrets.SSH_PRIVATE_KEY }}"
+      - name: Deploy to EC2 instancd
+        if: github.ref == 'refs/heads/alexi-deploy-cd' # todo: rename to 'main'
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: -avzr --delete
+          path: ./homeassistant-config
+          remote_path: /home/homeassistant/
+          remote_host: ec2-35-91-223-141.us-west-2.compute.amazonaws.com # todo: make a repo variable?
+          remote_user: ubuntu
+          remote_key: "${{ secrets.SSH_PRIVATE_KEY }}"
     
   on-failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,7 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - run: echo "First workflow was a success"
+      - run: echo "Checks pass, deploying"
+    - name: Deploy to EC2 instancd
+      if: github.ref == 'refs/heads/alexi-deploy-cd'
+      uses: burnett01/rsync-deployments@5.1
+      with:
+        switches: -avzr --delete
+        path: ./homeassistant-config
+        remote_path: /home/homeassistant/
+        remote_host: ec2-35-91-223-141.us-west-2.compute.amazonaws.com # todo: make a repo variable?
+        remote_user: ubuntu
+        remote_key: "${{ secrets.SSH_PRIVATE_KEY }}"
+    
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}


### PR DESCRIPTION
In theory, this will deploy code from the `homeassistant-config/` folder up to the HA directory in the EC2 instance. Like I said before, there doesn't seem to be a way to test this not on `main`.