### PR TITLE
Change to manual dispatch

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,9 +8,14 @@
 name: Deploy
 
 on:
-  workflow_run: # Only run this if linting and testing pass
-    workflows: [Lint, Check] # Necessary checks
-    types: [completed] # Only run when the checks have completed
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: 'warning'
+      tags:
+        description: 'Test tags'
 
 jobs:
   on-success:


### PR DESCRIPTION
This makes it so that deployment is manual (we gotta go into Github and push a button). This is my preference so that while it's still easy to deploy code, it doesn't happen unless someone explicitly tells it to.